### PR TITLE
fix: batch archive and purge queries to prevent statement timeout

### DIFF
--- a/src/plans.js
+++ b/src/plans.js
@@ -679,25 +679,35 @@ function insertJobs (schema) {
 
 function purge (schema, interval) {
   return `
-    DELETE FROM ${schema}.archive
-    WHERE archivedOn < (now() - interval '${interval}')
+    DELETE FROM ${schema}.archive a
+    USING (
+      SELECT id FROM ${schema}.archive
+      WHERE archivedOn < (now() - interval '${interval}')
+      LIMIT 20000
+    ) candidates
+    WHERE a.id = candidates.id
   `
 }
 
 function archive (schema, completedInterval, failedInterval = completedInterval) {
   return `
     WITH archived_rows AS (
-      DELETE FROM ${schema}.job
-      WHERE (
-          state <> '${states.failed}' AND completedOn < (now() - interval '${completedInterval}')
-        )
-        OR (
-          state = '${states.failed}' AND completedOn < (now() - interval '${failedInterval}')
-        )
-        OR (
-          state < '${states.active}' AND keepUntil < now()
-        )
-      RETURNING *
+      DELETE FROM ${schema}.job j
+      USING (
+        SELECT id FROM ${schema}.job
+        WHERE (
+            state <> '${states.failed}' AND completedOn < (now() - interval '${completedInterval}')
+          )
+          OR (
+            state = '${states.failed}' AND completedOn < (now() - interval '${failedInterval}')
+          )
+          OR (
+            state < '${states.active}' AND keepUntil < now()
+          )
+        LIMIT 10000
+      ) candidates
+      WHERE j.id = candidates.id
+      RETURNING j.*
     )
     INSERT INTO ${schema}.archive (
       id, name, priority, data, state, retryLimit, retryCount, retryDelay, retryBackoff, startAfter, startedOn, singletonKey, singletonOn, expireIn, createdOn, completedOn, keepUntil, on_complete, output

--- a/src/plans.js
+++ b/src/plans.js
@@ -677,6 +677,9 @@ function insertJobs (schema) {
   `
 }
 
+// USING with LIMIT: batches deletes to stay within the 30s statement_timeout set by locked().
+// WHERE id IN (subquery) was avoided as it can cause a double scan on large tables;
+// USING lets the planner execute a single Hash/Nested Loop join against the candidate rows.
 function purge (schema, interval) {
   return `
     DELETE FROM ${schema}.archive a
@@ -689,6 +692,9 @@ function purge (schema, interval) {
   `
 }
 
+// USING with LIMIT: batches deletes to stay within the 30s statement_timeout set by locked().
+// WHERE id IN (subquery) was avoided as it can cause a double scan on large tables;
+// USING lets the planner execute a single Hash/Nested Loop join against the candidate rows.
 function archive (schema, completedInterval, failedInterval = completedInterval) {
   return `
     WITH archived_rows AS (


### PR DESCRIPTION
## Summary

- Wraps the `archive` DELETE (`pgboss.job` → `pgboss.archive`) in a `USING` subquery with `LIMIT 10000` per maintenance cycle
- Wraps the `purge` DELETE (`pgboss.archive`) in a `USING` subquery with `LIMIT 20000` per maintenance cycle
- Prevents unbounded transactions that exceed the hard-coded 30s `statement_timeout` in the `locked()` wrapper when tables have a large backlog

## Background

The `archive` and `purge` maintenance queries run inside a 30s `statement_timeout` set in `plans.locked()`. On large tables with a backlog, unbounded DELETEs exceed the timeout, fail, and are retried — creating a feedback loop that worsens the backlog over time. Batching ensures each cycle completes well within 30s and drains the backlog incrementally.

## Why USING instead of WHERE id IN (subquery)

`WHERE id IN (SELECT id ... LIMIT n)` causes a double scan: the inner subquery finds the candidate IDs, then the outer DELETE performs a separate PK index lookup for each one. On large tables (hundreds of millions of rows) this adds unnecessary overhead.

`DELETE ... USING (SELECT ... LIMIT n) candidates WHERE t.id = candidates.id` lets the planner execute a single Hash Join or Nested Loop directly against the candidate rows, avoiding the second scan. On a 430M row archive table the difference is meaningful.

## Test plan

- [ ] Verify `archive` moves up to 10,000 rows per maintenance cycle
- [ ] Verify `purge` deletes up to 20,000 rows per maintenance cycle
- [ ] Confirm both complete within 30s on large tables
- [ ] Confirm no rows are skipped or double-processed across cycles