### PR TITLE
fix: increase archive and purge batch limits to 100000

### DIFF
--- a/src/plans.js
+++ b/src/plans.js
@@ -686,7 +686,7 @@ function purge (schema, interval) {
     USING (
       SELECT id FROM ${schema}.archive
       WHERE archivedOn < (now() - interval '${interval}')
-      LIMIT 20000
+      LIMIT 100000
     ) candidates
     WHERE a.id = candidates.id
   `
@@ -710,7 +710,7 @@ function archive (schema, completedInterval, failedInterval = completedInterval)
           OR (
             state < '${states.active}' AND keepUntil < now()
           )
-        LIMIT 25000
+        LIMIT 100000
       ) candidates
       WHERE j.id = candidates.id
       RETURNING j.*

--- a/src/plans.js
+++ b/src/plans.js
@@ -710,7 +710,7 @@ function archive (schema, completedInterval, failedInterval = completedInterval)
           OR (
             state < '${states.active}' AND keepUntil < now()
           )
-        LIMIT 10000
+        LIMIT 25000
       ) candidates
       WHERE j.id = candidates.id
       RETURNING j.*


### PR DESCRIPTION
## Summary
- Raises the batch `LIMIT` in the archive job-deletion query (introduced in #6) from 10000 to 100000 rows per run.
- Raises the batch `LIMIT` in the purge query (introduced in #6) from 20000 to 100000 rows per run.

## Test plan
- [ ] Verify archive/purge jobs run within the 30s statement timeout on a large table at the new batch size.