### PR TITLE
feat: dynamic archive maintenance query config from configcat FF 

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -343,11 +343,6 @@ Queue options contain the following constructor-only settings.
 
   Default: 12 hours
 
-* **archiveFailedAfterSeconds**
-
-    Specifies how long in seconds failed jobs get archived. Note: a warning will be emitted if set to lower than 60s and cron processing will be disabled.
-
-  Default: `archiveCompletedAfterSeconds`
 
 **Monitoring options**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pg-boss",
-  "version": "9.0.3",
+  "version": "9.0.3-supabase",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pg-boss",
-      "version": "9.0.3",
+      "version": "9.0.3-supabase",
       "license": "MIT",
       "dependencies": {
         "cron-parser": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "scripts": {
     "test": "standard && mocha",
+    "test:unit": "node test/isSQLIntervalTest.js",
     "cover": "nyc npm test",
     "export-schema": "node ./scripts/construct.js",
     "export-migration": "node ./scripts/migrate.js",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "test": "standard && mocha",
-    "test:unit": "node test/isSQLIntervalTest.js",
+    "test:unit": "node test/isSQLIntervalTest.js && node test/isSQLTimeoutTest.js",
     "cover": "nyc npm test",
     "export-schema": "node ./scripts/construct.js",
     "export-migration": "node ./scripts/migrate.js",

--- a/src/attorney.js
+++ b/src/attorney.js
@@ -161,7 +161,6 @@ function getConfig (value) {
   applyDatabaseConfig(config)
   applyMaintenanceConfig(config)
   applyArchiveConfig(config)
-  applyArchiveFailedConfig(config)
   applyDeleteConfig(config)
   applyMonitoringConfig(config)
   applyUuidConfig(config)
@@ -198,18 +197,6 @@ function applyArchiveConfig (config) {
   }
 }
 
-function applyArchiveFailedConfig (config) {
-  assert(!('archiveFailedAfterSeconds' in config) || config.archiveFailedAfterSeconds >= 1,
-    'configuration assert: archiveFailedAfterSeconds must be at least every second and less than ')
-
-  config.archiveFailedSeconds = config.archiveFailedAfterSeconds || config.archiveSeconds
-  config.archiveFailedInterval = `${config.archiveFailedSeconds} seconds`
-
-  // Do not emit warning twice
-  if (config.archiveFailedSeconds < 60 && config.archiveSeconds >= 60) {
-    emitWarning(WARNINGS.CRON_DISABLED)
-  }
-}
 
 function applyCompletionConfig (config, defaults) {
   assert(!('onComplete' in config) || config.onComplete === true || config.onComplete === false,

--- a/src/attorney.js
+++ b/src/attorney.js
@@ -197,7 +197,6 @@ function applyArchiveConfig (config) {
   }
 }
 
-
 function applyCompletionConfig (config, defaults) {
   assert(!('onComplete' in config) || config.onComplete === true || config.onComplete === false,
     'configuration assert: onComplete must be either true or false')

--- a/src/boss.js
+++ b/src/boss.js
@@ -17,8 +17,12 @@ const events = {
 // flag values below are interpolated straight into SQL; only allow simple
 // "<number> <optional unit>" strings (e.g. '30s', '21600 seconds') so a
 // bad/malicious ConfigCat edit can't break the query or inject
-const INTERVAL_PATTERN = /^\d+\s*(ms|s|m|h|d|seconds?|minutes?|hours?|days?)$/i
+// Note: digit could be negative, but we don't want to support that
+// Note2: centuries, millienia also technical valid; but we don't want to support that either
+const INTERVAL_PATTERN = /^\d+\s*(ms|milliseconds?|s|seconds?|mins?|minutes?|h|hours?|d|days?|w|weeks?|m|months?|y|years?)$/i
+const TIMEOUT_PATTERN = /^\d+\s*(ms|s|min|h|d)$/i
 const isSQLInterval = (value) => typeof value === 'string' && INTERVAL_PATTERN.test(value.trim())
+const isSQLTimeout = (value) => typeof value === 'string' && TIMEOUT_PATTERN.test(value.trim())
 
 // Check we have a feature flag client with the required lookup method/func and use this to pull
 // the maintenance query params from the feature flag `archiveConfigFlagName`.
@@ -269,7 +273,7 @@ class Boss extends EventEmitter {
     if (flag) {
       if (isSQLInterval(flag.archiveJobAgeLimit)) archiveJobAgeLimit = flag.archiveJobAgeLimit
       if (Number.isInteger(flag.archiveBatchSize) && flag.archiveBatchSize > 0) archiveBatchSize = flag.archiveBatchSize
-      if (isSQLInterval(flag.statementTimeout)) statementTimeout = flag.statementTimeout
+      if (isSQLTimeout(flag.statementTimeout)) statementTimeout = flag.statementTimeout
     }
 
     const command = plans.locked(
@@ -314,3 +318,4 @@ class Boss extends EventEmitter {
 module.exports = Boss
 module.exports.QUEUES = queues
 module.exports.isSQLInterval = isSQLInterval
+module.exports.isSQLTimeout = isSQLTimeout

--- a/src/boss.js
+++ b/src/boss.js
@@ -17,7 +17,7 @@ const events = {
 // flag values below are interpolated straight into SQL; only allow simple
 // "<number> <optional unit>" strings (e.g. '30s', '21600 seconds') so a
 // bad/malicious ConfigCat edit can't break the query or inject
-const INTERVAL_PATTERN = /^\d+\s*(ms|s|m|h|d|seconds?|minutes?|hours?|days?)?$/i
+const INTERVAL_PATTERN = /^\d+\s*(ms|s|m|h|d|seconds?|minutes?|hours?|days?)$/i
 const isSQLInterval = (value) => typeof value === 'string' && INTERVAL_PATTERN.test(value.trim())
 
 // Check we have a feature flag client with the required lookup method/func and use this to pull
@@ -30,13 +30,13 @@ const getMaintenanceConfigFromFlag = async (config, emitError) => {
   const {
     featureFlagClient: client,
     archiveConfigFlagName: flagName
-  } = config;
+  } = config
 
-  if(
-    !client
-    || typeof client.getValueAsync !== 'function'
-    || !flagName
-  ){
+  if (
+    !client ||
+    typeof client.getValueAsync !== 'function' ||
+    !flagName
+  ) {
     return flag
   }
 
@@ -50,7 +50,7 @@ const getMaintenanceConfigFromFlag = async (config, emitError) => {
     emitError(new Error(`[pg-boss] could not fetch/parse ${flagName} flag; using configured defaults`))
   }
 
-  return flag;
+  return flag
 }
 
 class Boss extends EventEmitter {
@@ -313,3 +313,4 @@ class Boss extends EventEmitter {
 
 module.exports = Boss
 module.exports.QUEUES = queues
+module.exports.isSQLInterval = isSQLInterval

--- a/src/boss.js
+++ b/src/boss.js
@@ -14,6 +14,45 @@ const events = {
   maintenance: 'maintenance'
 }
 
+// flag values below are interpolated straight into SQL; only allow simple
+// "<number> <optional unit>" strings (e.g. '30s', '21600 seconds') so a
+// bad/malicious ConfigCat edit can't break the query or inject
+const INTERVAL_PATTERN = /^\d+\s*(ms|s|m|h|d|seconds?|minutes?|hours?|days?)?$/i
+const isSQLInterval = (value) => typeof value === 'string' && INTERVAL_PATTERN.test(value.trim())
+
+// Check we have a feature flag client with the required lookup method/func and use this to pull
+// the maintenance query params from the feature flag `archiveConfigFlagName`.
+//
+// @returns JSON | null
+const getMaintenanceConfigFromFlag = async (config, emitError) => {
+  let flag = null
+
+  const {
+    featureFlagClient: client,
+    archiveConfigFlagName: flagName
+  } = config;
+
+  if(
+    !client
+    || typeof client.getValueAsync !== 'function'
+    || !flagName
+  ){
+    return flag
+  }
+
+  try {
+    // ConfigCat auto-polls every 60s; getValueAsync reads the in-memory cache, no network call per invocation
+    const f = await client.getValueAsync(flagName, null)
+    flag = f ? JSON.parse(f) : null
+  } catch (_err) { /* FF unavailable or unparseable — fall back to configured defaults */ }
+
+  if (!flag) {
+    emitError(new Error(`[pg-boss] could not fetch/parse ${flagName} flag; using configured defaults`))
+  }
+
+  return flag;
+}
+
 class Boss extends EventEmitter {
   constructor (db, config) {
     super()
@@ -33,7 +72,6 @@ class Boss extends EventEmitter {
     this.events = events
 
     this.expireCommand = plans.locked(config.schema, plans.expire(config.schema))
-    this.archiveCommand = plans.locked(config.schema, plans.archive(config.schema, config.archiveInterval))
     this.purgeCommand = plans.locked(config.schema, plans.purge(config.schema, config.deleteAfter))
     this.getMaintenanceTimeCommand = plans.getMaintenanceTime(config.schema)
     this.setMaintenanceTimeCommand = plans.setMaintenanceTime(config.schema)
@@ -127,10 +165,12 @@ class Boss extends EventEmitter {
         throw new Error(this.config.__test__throw_maint)
       }
 
+      // [optionally] pull maintenance query details from a feature flag
+      const flag = await getMaintenanceConfigFromFlag(this.config, (e) => this.emit(events.error, e))
       const started = Date.now()
 
       await this.expire()
-      await this.archive()
+      await this.archive(flag)
       await this.purge()
 
       const ended = Date.now()
@@ -141,7 +181,12 @@ class Boss extends EventEmitter {
 
       if (!this.stopped) {
         await this.manager.complete(job.id) // pre-complete to bypass throttling
-        await this.maintenanceAsync({ startAfter: this.maintenanceIntervalSeconds })
+        // maintenanceInterval = 0 -- Invalid
+        // maintenanceInterval < 20 -- likely impractical, but depends on user workload. So we don't enforce a minimum
+        const maintenanceInterval = (flag && Number.isFinite(flag.maintenanceInterval) && flag.maintenanceInterval > 0)
+          ? flag.maintenanceInterval
+          : this.maintenanceIntervalSeconds // lib defaults | client config
+        await this.maintenanceAsync({ startAfter: maintenanceInterval })
       }
     } catch (err) {
       this.emit(events.error, err)
@@ -216,8 +261,23 @@ class Boss extends EventEmitter {
     await this.executeSql(this.expireCommand)
   }
 
-  async archive () {
-    await this.executeSql(this.archiveCommand)
+  async archive (flag = null) {
+    let archiveJobAgeLimit = this.config.archiveInterval
+    let archiveBatchSize // use default in plans.archive() func
+    let statementTimeout // use default in plans.locked() func
+
+    if (flag) {
+      if (isSQLInterval(flag.archiveJobAgeLimit)) archiveJobAgeLimit = flag.archiveJobAgeLimit
+      if (Number.isInteger(flag.archiveBatchSize) && flag.archiveBatchSize > 0) archiveBatchSize = flag.archiveBatchSize
+      if (isSQLInterval(flag.statementTimeout)) statementTimeout = flag.statementTimeout
+    }
+
+    const command = plans.locked(
+      this.config.schema,
+      plans.archive(this.config.schema, archiveJobAgeLimit, archiveBatchSize),
+      statementTimeout
+    )
+    await this.executeSql(command)
   }
 
   async purge () {

--- a/src/boss.js
+++ b/src/boss.js
@@ -33,7 +33,7 @@ class Boss extends EventEmitter {
     this.events = events
 
     this.expireCommand = plans.locked(config.schema, plans.expire(config.schema))
-    this.archiveCommand = plans.locked(config.schema, plans.archive(config.schema, config.archiveInterval, config.archiveFailedInterval))
+    this.archiveCommand = plans.locked(config.schema, plans.archive(config.schema, config.archiveInterval))
     this.purgeCommand = plans.locked(config.schema, plans.purge(config.schema, config.deleteAfter))
     this.getMaintenanceTimeCommand = plans.getMaintenanceTime(config.schema)
     this.setMaintenanceTimeCommand = plans.setMaintenanceTime(config.schema)

--- a/src/plans.js
+++ b/src/plans.js
@@ -695,17 +695,14 @@ function purge (schema, interval) {
 // USING with LIMIT: batches deletes to stay within the 30s statement_timeout set by locked().
 // WHERE id IN (subquery) was avoided as it can cause a double scan on large tables;
 // USING lets the planner execute a single Hash/Nested Loop join against the candidate rows.
-function archive (schema, completedInterval, failedInterval = completedInterval) {
+function archive (schema, completedInterval) {
   return `
     WITH archived_rows AS (
       DELETE FROM ${schema}.job j
       USING (
         SELECT id FROM ${schema}.job
         WHERE (
-            state <> '${states.failed}' AND completedOn < (now() - interval '${completedInterval}')
-          )
-          OR (
-            state = '${states.failed}' AND completedOn < (now() - interval '${failedInterval}')
+            completedOn < now() - interval '${completedInterval}'
           )
           OR (
             state < '${states.active}' AND keepUntil < now()

--- a/src/plans.js
+++ b/src/plans.js
@@ -63,14 +63,14 @@ module.exports = {
   DEFAULT_SCHEMA
 }
 
-function locked (schema, query) {
+function locked (schema, query, timeout = '30s') {
   if (Array.isArray(query)) {
     query = query.join(';\n')
   }
 
   return `
     BEGIN;
-    SET LOCAL statement_timeout = '30s';
+    SET LOCAL statement_timeout = '${timeout}';
     ${advisoryLock(schema)};
     ${query};
     COMMIT;
@@ -695,19 +695,19 @@ function purge (schema, interval) {
 // USING with LIMIT: batches deletes to stay within the 30s statement_timeout set by locked().
 // WHERE id IN (subquery) was avoided as it can cause a double scan on large tables;
 // USING lets the planner execute a single Hash/Nested Loop join against the candidate rows.
-function archive (schema, completedInterval) {
+function archive (schema, completedAge, limit = 100000) {
   return `
     WITH archived_rows AS (
       DELETE FROM ${schema}.job j
       USING (
         SELECT id FROM ${schema}.job
         WHERE (
-            completedOn < now() - interval '${completedInterval}'
+            completedOn < now() - interval '${completedAge}'
           )
           OR (
             state < '${states.active}' AND keepUntil < now()
           )
-        LIMIT 100000
+        LIMIT ${limit}
       ) candidates
       WHERE j.id = candidates.id
       RETURNING j.*

--- a/src/timekeeper.js
+++ b/src/timekeeper.js
@@ -45,7 +45,7 @@ class Timekeeper extends EventEmitter {
 
   async start () {
     // setting the archive config too low breaks the cron 60s debounce interval so don't even try
-    if (this.config.archiveSeconds < 60 || this.config.archiveFailedSeconds < 60) {
+    if (this.config.archiveSeconds < 60) {
       return
     }
 

--- a/test/archiveTest.js
+++ b/test/archiveTest.js
@@ -96,4 +96,43 @@ describe('archive', function () {
     assert.strictEqual(queue, archivedJob.name)
     assert.strictEqual(states.failed, archivedJob.state)
   })
+
+  const fakeFlagClient = (value) => ({ getValueAsync: async () => value })
+  const archiveConfigFlagName = 'archive-config'
+
+  it('should apply archiveJobAgeLimit from the feature flag over config', async function () {
+    // config says archive after 1s, but the flag raises the age limit to 1h -> nothing archived
+    const featureFlagClient = fakeFlagClient(JSON.stringify({ archiveJobAgeLimit: '3600 seconds' }))
+    const config = { ...this.test.bossConfig, ...defaults, featureFlagClient, archiveConfigFlagName }
+    const boss = this.test.boss = await helper.start(config)
+    const queue = this.test.bossConfig.schema
+
+    const jobId = await boss.send(queue)
+    await boss.fetch(queue)
+    await boss.complete(jobId)
+
+    await delay(4000)
+
+    const archivedJob = await helper.getArchivedJobById(config.schema, jobId)
+
+    assert.strictEqual(archivedJob, null)
+  })
+
+  it('should fall back to config when the feature flag is malformed', async function () {
+    const featureFlagClient = fakeFlagClient('not valid json{')
+    const config = { ...this.test.bossConfig, ...defaults, featureFlagClient, archiveConfigFlagName }
+    const boss = this.test.boss = await helper.start(config)
+    const queue = this.test.bossConfig.schema
+
+    const jobId = await boss.send(queue)
+    await boss.fetch(queue)
+    await boss.complete(jobId)
+
+    await delay(4000)
+
+    const archivedJob = await helper.getArchivedJobById(config.schema, jobId)
+
+    assert.strictEqual(jobId, archivedJob.id)
+    assert.strictEqual(queue, archivedJob.name)
+  })
 })

--- a/test/archiveTest.js
+++ b/test/archiveTest.js
@@ -79,24 +79,8 @@ describe('archive', function () {
     assert.strictEqual(queue, archivedJob.name)
   })
 
-  it('should not archive a failed job before the config setting', async function () {
-    const config = { ...this.test.bossConfig, ...defaults, archiveFailedAfterSeconds: 10 }
-    const boss = this.test.boss = await helper.start(config)
-    const queue = this.test.bossConfig.schema
-
-    const failPayload = { someReason: 'nuna' }
-    const jobId = await boss.send(queue, null, { retentionSeconds: 1 })
-
-    await boss.fail(jobId, failPayload)
-    await delay(7000)
-
-    const archivedJob = await helper.getArchivedJobById(config.schema, jobId)
-
-    assert.strictEqual(archivedJob, null)
-  })
-
   it('should archive a failed job', async function () {
-    const config = { ...this.test.bossConfig, maintenanceIntervalSeconds: 1, archiveFailedAfterSeconds: 1 }
+    const config = { ...this.test.bossConfig, maintenanceIntervalSeconds: 1, archiveCompletedAfterSeconds: 1 }
     const boss = this.test.boss = await helper.start(config)
     const queue = this.test.bossConfig.schema
 

--- a/test/isSQLIntervalTest.js
+++ b/test/isSQLIntervalTest.js
@@ -1,0 +1,60 @@
+const assert = require('assert')
+const { isSQLInterval } = require('../src/boss')
+
+const valid = [
+  '30s',
+  '1m',
+  '2h',
+  '7d',
+  '60 seconds',
+  '60 second',
+  '30 minutes',
+  '30 minute',
+  '2 hours',
+  '2 hour',
+  '1 days',
+  '1 day',
+  '500 ms',
+  '21600 seconds',
+  '  30s  ' // trimmed
+]
+
+const invalid = [
+  null,
+  undefined,
+  42,
+  true,
+  0,
+  '0',
+  '30', // if we give a number, we need units to avoid accidental milliseconds
+  '',
+  'abc',
+  '1x',
+  '1 week',
+  '1 year',
+  '1s; DROP TABLE jobs',
+  "1' OR '1'='1",
+  '1s 2m',
+  '-1s',
+  '1.5s'
+]
+
+let passed = 0
+let failed = 0
+
+function test (name, fn) {
+  try {
+    fn()
+    process.stdout.write(`  ✓ ${name}\n`)
+    passed++
+  } catch (e) {
+    process.stdout.write(`  ✗ ${name}: ${e.message}\n`)
+    failed++
+  }
+}
+
+for (const v of valid) { test(`accepts ${JSON.stringify(v)}`, () => assert.strictEqual(isSQLInterval(v), true)) }
+for (const v of invalid) { test(`rejects ${JSON.stringify(v)}`, () => assert.strictEqual(isSQLInterval(v), false)) }
+
+process.stdout.write(`\n${passed} passing, ${failed} failing\n`)
+if (failed) process.exit(1)

--- a/test/isSQLTimeoutTest.js
+++ b/test/isSQLTimeoutTest.js
@@ -1,28 +1,14 @@
 const assert = require('assert')
-const { isSQLInterval } = require('../src/boss')
+const { isSQLTimeout } = require('../src/boss')
 
 const valid = [
-  '60 seconds',
-  '21600 seconds',
-  '60 second',
-  '30 minutes',
-  '30 minute',
-  '2 hours',
-  '2 hour',
-  '3hour',
-  '1 days',
-  '1 day',
-  '3day',
-  '1 week',
+  '7d',
   '30s',
   '2h',
   '20min',
   '500 ms',
   '500ms',
-  '  30s  ', // trimmed
-  '1m',
-  '7d',
-  '1 year',
+  '  30s  ' // trimmed
 ]
 
 const invalid = [
@@ -36,11 +22,26 @@ const invalid = [
   '',
   'abc',
   '1x',
+  '1m',
+  '1.5s',
+  '1 week',
+  '1 year',
   '1s; DROP TABLE jobs',
   "1' OR '1'='1",
   '1s 2m',
   '-1s',
-  '1.5s',
+  '500 millisecondss',
+  '500milliseconds',
+  '60 seconds',
+  '21600 seconds',
+  '60 second',
+  '30 minutes',
+  '30 minute',
+  '2 hours',
+  '2 hour',
+  '1 days',
+  '1 day',
+  '  30seconds  ' // trimmed
 ]
 
 let passed = 0
@@ -57,12 +58,12 @@ function test (name, fn) {
   }
 }
 
-console.log('isSQLInterval')
+console.log('isSQLTimeout')
 for (const v of valid) {
-  test(`accepts ${JSON.stringify(v)}`, () => assert.strictEqual(isSQLInterval(v), true))
+  test(`accepts ${JSON.stringify(v)}`, () => assert.strictEqual(isSQLTimeout(v), true))
 }
 for (const v of invalid) {
-  test(`rejects ${JSON.stringify(v)}`, () => assert.strictEqual(isSQLInterval(v), false))
+  test(`rejects ${JSON.stringify(v)}`, () => assert.strictEqual(isSQLTimeout(v), false))
 }
 
 process.stdout.write(`\n${passed} passing, ${failed} failing\n`)

--- a/types.d.ts
+++ b/types.d.ts
@@ -31,6 +31,16 @@ declare namespace PgBoss {
     clockMonitorIntervalSeconds?: number;
     clockMonitorIntervalMinutes?: number;
   }
+  interface ArchiveFeatureFlag {
+    // When maintenance job should run (seconds), e.g. 30 [default: configured at PgBoss client instantiation]
+    maintenanceInterval?: number;
+    // Max age of job to be archived, e.g. '21600 seconds'
+    archiveJobAgeLimit?: string;
+    // Number of rows to purge in 1 go, e.g. 10000 [default: 100000]
+    archiveBatchSize?: number;
+    // Transaction statement timeout for maintenance query, e.g. '30s' [default '30s']
+    statementTimeout?: string;
+  }
 
   interface MaintenanceOptions {
     noSupervisor?: boolean;
@@ -44,6 +54,10 @@ declare namespace PgBoss {
     maintenanceIntervalMinutes?: number;
 
     archiveCompletedAfterSeconds?: number;
+
+    // getValueAsync returns the raw flag value; pg-boss JSON.parses it into an ArchiveFeatureFlag
+    featureFlagClient?: { getValueAsync(key: string, defaultValue: string | null): Promise<string | null> };
+    archiveConfigFlagName?: string;
   }
 
   type ConstructorOptions =

--- a/types.d.ts
+++ b/types.d.ts
@@ -36,7 +36,7 @@ declare namespace PgBoss {
     maintenanceInterval?: number;
     // Max age of job to be archived, e.g. '21600 seconds'
     archiveJobAgeLimit?: string;
-    // Number of rows to purge in 1 go, e.g. 10000 [default: 100000]
+    // Number of rows to archive in 1 go, e.g. 10000 [default: 100000]
     archiveBatchSize?: number;
     // Transaction statement timeout for maintenance query, e.g. '30s' [default '30s']
     statementTimeout?: string;

--- a/types.d.ts
+++ b/types.d.ts
@@ -44,7 +44,6 @@ declare namespace PgBoss {
     maintenanceIntervalMinutes?: number;
 
     archiveCompletedAfterSeconds?: number;
-    archiveFailedAfterSeconds?: number;
   }
 
   type ConstructorOptions =


### PR DESCRIPTION
## What kind of change does this PR introduce?

feat + refactor

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Introduce new ability to pull maintenance query scope from FF + simplification:

1) Remove the distinction between jobs in `failed` state vs `completed` in the
context of the maintenance workflow (moving jobs from `job` -> `archive` table)

2) Introduce config cat FF support so we can inject the maintenance workflow
params live: interval between maintenance runs, and the batch size of rows to be
moved per cycle, timewindow for jobs to be archived, etc. This will help tune 
the archiving rate as platform load grows, allowing us to do so without library releases.

Can inject config cat client, or will fallback to simple client if flag is
defined. 


## Additional context

Add any other context or screenshots.